### PR TITLE
Add support for CentOS 7

### DIFF
--- a/remi/init.sls
+++ b/remi/init.sls
@@ -10,6 +10,11 @@
     'key_hash': 'md5=3abb4e5a7b1408c888e19f718c012630',
     'rpm': 'http://mirrors.mediatemple.net/remi/enterprise/remi-release-6.rpm',
   },
+  'CentOS-7': {
+    'key': 'http://rpms.famillecollet.com/RPM-GPG-KEY-remi',
+    'key_hash': 'md5=3abb4e5a7b1408c888e19f718c012630',
+    'rpm': 'http://mirrors.mediatemple.net/remi/enterprise/remi-release-7.rpm',
+  },
 }, 'osfinger') %}
 
 # Completely ignore non-CentOS, non-RHEL systems


### PR DESCRIPTION
Remi has added a new RPM specific to CentOS 7.

GPG key is the same.

See http://blog.famillecollet.com/pages/Config-en 
